### PR TITLE
Fix utf8 encoding issues during authentication

### DIFF
--- a/pyGoogleTrendsCsvDownloader.py
+++ b/pyGoogleTrendsCsvDownloader.py
@@ -85,7 +85,11 @@ class pyGoogleTrendsCsvDownloader(object):
             xmlTree = etree.fromstring(data, parser=html.HTMLParser(recover=True, remove_comments=True))
             
             for input in find_inputs(xmlTree):
-                self.login_params[input.get("name")] = input.get("value")
+                name = input.get('name')
+                if name:
+                    name = name.encode('utf8')
+                    value = input.get('value', '').encode('utf8')
+                    self.login_params[name] = value
         except:
             print("Exception while parsing: %s\n" % traceback.format_exc())    
         


### PR DESCRIPTION
Google's login form includes a hidden field called _utf8 which contains \u2603,
which is a snowman, probably as a workaround to force IE5-8 to read and encode
things in UTF-8.

This doesn't interact very well with urllib.urlencode, which bails out with a
ValueError, so this commit pre-encodes strings using .encode() to avoid this
scenario.
