### PR TITLE
Fixing: You've exceeded your quota. Continue tomorrow... 

### DIFF
--- a/pyGoogleTrendsCsvDownloader.py
+++ b/pyGoogleTrendsCsvDownloader.py
@@ -63,9 +63,11 @@ class pyGoogleTrendsCsvDownloader(object):
         
         # Make sure we get CSV results in English
         ck = Cookie(version=0, name='I4SUserLocale', value='en_US', port=None, port_specified=False, domain='www.google.com', domain_specified=False,domain_initial_dot=False, path='/trends', path_specified=True, secure=False, expires=None, discard=False, comment=None, comment_url=None, rest=None)
-        
+        ck_pref = Cookie(version=0, name='PREF', value='', port=None, port_specified=False, domain='www.google.com', domain_specified=False,domain_initial_dot=False, path='/trends', path_specified=True, secure=False, expires=None, discard=False, comment=None, comment_url=None, rest=None) 
+
         self.cj = CookieJar()                            
         self.cj.set_cookie(ck)
+        self.cj.set_cookie(ck_pref)
         self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cj))
         self.opener.addheaders = self.headers
         


### PR DESCRIPTION
by adding PREF cookie.

Test: 

from pyGoogleTrendsCsvDownloader import pyGoogleTrendsCsvDownloader

r = pyGoogleTrendsCsvDownloader(login, password)

for i in range(500):
    r.get_csv(cat='0-958', geo='US-ME-500')
    print i

2 runs: without and with the patch

savril@ubuntu:~/workspace/google-trends-csv-downloader$ python test.py
You've exceeded your quota. Continue tomorrow...
savril@ubuntu:~/workspace/google-trends-csv-downloader$ python test.py
0
1
2
3
4
5
6
7
8
9
10
11
12
13
14
^CTraceback (most recent call last):
